### PR TITLE
touch /etc/motd if it does not exist.

### DIFF
--- a/bootstrap/motd.sls
+++ b/bootstrap/motd.sls
@@ -1,6 +1,5 @@
-touch /etc/motd:
-  cmd.run:
-    - creates: /etc/motd
+/etc/motd:
+  file.touch
 
 motd_quote:
   file.append:


### PR DESCRIPTION
/etc/motd file does not exist on the default
Ubuntu 14.04 EC2 image. This simply touches the
file if it doesn't exist before executing the
following `file.append` function.
