### PR TITLE
Framework for linux kernel upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Version 3.x.0 (unreleased)
+
+* Upgrade GRUB to grub-pc (v2), since GRUBv1 on vCD templates was in error
+* Permit upgrade of kernel -- encourage by default, set grain 'lock_kernel_version' to postpone.
+
 ## Version 2.1.2
 
 * Fix. Make locales generation idempotent.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,20 @@
+
+Migration to v3.0.0
+-------------------
+
+v3.0.0 will upgrade GRUB to v2 (grub-pc) if it is downgraded. You can set pillar 
+`bootstrap.upgrade_grub` to `False` if you wish to postpone this.
+
+v3.0.0 will also upgrade to a known-secure and supported kernel. This means for 12.04 LTS boxes
+you will be upgraded to the 'lts-trusty' kernel. 14.04 LTS users will be upgraded to the version
+specified in map.jinja.
+
+This process can be postponed by setting grain `lock_kernel_version` to `True` on your nodes.
+
+Eg, to roll this out piecemeal, do the following:
+
+    salt '*' grains.setval lock_kernel_version True
+
+    salt 'node01' grains.setval lock_kernel_version False
+
+Though it should be fine to just upgrade all nodes, and reboot as required by your application.

--- a/bootstrap/grub.sls
+++ b/bootstrap/grub.sls
@@ -1,3 +1,25 @@
-/etc/grub.conf:
-  file.symlink:
-    - target: /boot/grub/grub.conf
+{% from "bootstrap/map.jinja" import bootstrap with context %}
+{% if bootstrap.upgrade_grub %}
+# upgrade grub if we are not using grub-pc
+# NB: This is done via cmd.run as pkg.installed would barf on questions asked.
+upgrade_to_grub_pc:
+  cmd.run:
+    - env: 
+      - DEBIAN_FRONTEND: 'noninteractive'
+    - name: "yes '' | apt-get -y -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install grub-pc"
+    - unless: 'dpkg -l | grep -q grub-pc'
+    - watch_in:
+      - cmd: grub_install_bootsector
+
+
+{% else %}
+upgrade_to_grub_pc:
+  cmd.run:
+    - name: 'echo "You must upgrade to grub-pc. See bootstrap-formula/README.rst" && false'
+    - unless: 'dpkg -l | grep -q grub-pc'
+
+{% endif %}
+
+grub_install_bootsector:
+  cmd.wait:
+    - name: "grub-install {{bootstrap.grub_install_device}}"

--- a/bootstrap/grub.sls
+++ b/bootstrap/grub.sls
@@ -1,5 +1,8 @@
 {% from "bootstrap/map.jinja" import bootstrap with context %}
-{% if bootstrap.upgrade_grub %}
+{% if salt['grains.get']('virtual') == 'xen' %}
+# we do not support updating grub on AWS
+{% else %}
+{%   if bootstrap.upgrade_grub %}
 # upgrade grub if we are not using grub-pc
 # NB: This is done via cmd.run as pkg.installed would barf on questions asked.
 upgrade_to_grub_pc:
@@ -11,15 +14,15 @@ upgrade_to_grub_pc:
     - watch_in:
       - cmd: grub_install_bootsector
 
+grub_install_bootsector:
+  cmd.wait:
+    - name: "grub-install {{bootstrap.grub_install_device}}"
 
-{% else %}
+{%   else %}
 upgrade_to_grub_pc:
   cmd.run:
     - name: 'echo "You must upgrade to grub-pc. See bootstrap-formula/README.rst" && false'
     - unless: 'dpkg -l | grep -q grub-pc'
 
+{%   endif %}
 {% endif %}
-
-grub_install_bootsector:
-  cmd.wait:
-    - name: "grub-install {{bootstrap.grub_install_device}}"

--- a/bootstrap/grub.sls
+++ b/bootstrap/grub.sls
@@ -1,6 +1,14 @@
 {% from "bootstrap/map.jinja" import bootstrap with context %}
-{% if salt['grains.get']('virtual') == 'xen' %}
-# we do not support updating grub on AWS
+{#
+When on AWS if we are using paravirtualization ("PV") we can't change the
+kernel easily, but on HVM you can.
+
+To tell the difference between AWS paravirtualization and hardware
+virtualization we look at the productname grain (and be restrictive about it,
+so this only happens where we expect it to)
+#}
+{% if salt['grains.get']('virtual') == 'xen' and salt['grains.get']('productname', '') != 'HVM domU' %}
+# we do not support updating grub on AWS PV
 {% else %}
 {%   if bootstrap.upgrade_grub %}
 # upgrade grub if we are not using grub-pc

--- a/bootstrap/init.sls
+++ b/bootstrap/init.sls
@@ -1,4 +1,6 @@
 include:
+  - .grub
+  - .kernel_version
   - .directories
   - .locale
   - .groups

--- a/bootstrap/kernel_version.sls
+++ b/bootstrap/kernel_version.sls
@@ -1,16 +1,18 @@
 {% from "bootstrap/map.jinja" import bootstrap with context %}
-{% if not salt['grains.get']("lock_kernel_version") or salt['grains.get']("lock_kernel_version") == False %}
+{% if salt['grains.get']("virtual") != 'xen' %}
+{%   if not salt['grains.get']("lock_kernel_version") or salt['grains.get']("lock_kernel_version") == False %}
 include:
   - .grub
 
 install_specific_linux_kernel:
   pkg.installed:
     - name: {{ bootstrap.kernel.meta_package }}
-{%   if bootstrap.kernel.version %}
+{%     if bootstrap.kernel.version %}
     - version: {{ bootstrap.kernel.version }}
-{%   endif %}
+{%     endif %}
     - require:
       - cmd: upgrade_to_grub_pc
     - watch_in:
       - cmd: grub_install_bootsector
+{%   endif %}
 {% endif %}

--- a/bootstrap/kernel_version.sls
+++ b/bootstrap/kernel_version.sls
@@ -1,0 +1,16 @@
+{% from "bootstrap/map.jinja" import bootstrap with context %}
+{% if not salt['grains.get']("lock_kernel_version") or salt['grains.get']("lock_kernel_version") == False %}
+include:
+  - .grub
+
+install_specific_linux_kernel:
+  pkg.installed:
+    - name: {{ bootstrap.kernel.meta_package }}
+{%   if bootstrap.kernel.version %}
+    - version: {{ bootstrap.kernel.version }}
+{%   endif %}
+    - require:
+      - cmd: upgrade_to_grub_pc
+    - watch_in:
+      - cmd: grub_install_bootsector
+{% endif %}

--- a/bootstrap/kernel_version.sls
+++ b/bootstrap/kernel_version.sls
@@ -1,5 +1,6 @@
 {% from "bootstrap/map.jinja" import bootstrap with context %}
-{% if salt['grains.get']("virtual") != 'xen' %}
+{# See grub.sls for more info on what this outer loop if is for #}
+{% if not(salt['grains.get']('virtual') == 'xen' and salt['grains.get']('productname', '') != 'HVM domU') %}
 {%   if not salt['grains.get']("lock_kernel_version") or salt['grains.get']("lock_kernel_version") == False %}
 include:
   - .grub

--- a/bootstrap/map.jinja
+++ b/bootstrap/map.jinja
@@ -4,8 +4,8 @@
        'upgrade_grub': True,
        'grub_install_device': '/dev/sda',
        'kernel': {
-         'meta_package': 'linux-generic-lts-trusty',
-         'version': '3.13.0.43.37'
+         'meta_package': 'linux-image-generic-lts-trusty',
+         'version': '3.13.0.55.48'
        }
     },
 
@@ -13,8 +13,8 @@
        'upgrade_grub': True,
        'grub_install_device': '/dev/sda',
        'kernel': {
-         'meta_package': 'linux-generic',
-         'version': '3.13.0.43.50'
+         'meta_package': 'linux-image-generic',
+         'version': '3.13.0.55.62'
        }
     },
 

--- a/bootstrap/map.jinja
+++ b/bootstrap/map.jinja
@@ -1,0 +1,29 @@
+{% set bootstrap = salt['grains.filter_by']({
+
+    'Ubuntu-12.04': {
+       'upgrade_grub': True,
+       'grub_install_device': '/dev/sda',
+       'kernel': {
+         'meta_package': 'linux-generic-lts-trusty',
+         'version': '3.13.0.43.37'
+       }
+    },
+
+    'Ubuntu-14.04': {
+       'upgrade_grub': True,
+       'grub_install_device': '/dev/sda',
+       'kernel': {
+         'meta_package': 'linux-generic',
+         'version': '3.13.0.43.50'
+       }
+    },
+
+    'Unknown': {
+       'upgrade_grub': False,
+       'kernel': {
+         'version': None
+       }
+    }
+
+}, grain='osfinger', merge=salt['pillar.get']('bootstrap',{}), default='Unknown') %}
+

--- a/bootstrap/map.jinja
+++ b/bootstrap/map.jinja
@@ -1,8 +1,9 @@
+{% %}
 {% set bootstrap = salt['grains.filter_by']({
 
     'Ubuntu-12.04': {
        'upgrade_grub': True,
-       'grub_install_device': '/dev/sda',
+       'grub_install_device': salt['grains.get']('SSDs:0') or '/dev/sda',
        'kernel': {
          'meta_package': 'linux-image-generic-lts-trusty',
          'version': '3.13.0.55.48'
@@ -11,7 +12,7 @@
 
     'Ubuntu-14.04': {
        'upgrade_grub': True,
-       'grub_install_device': '/dev/sda',
+       'grub_install_device': salt['grains.get']('SSDs:0') or '/dev/sda',
        'kernel': {
          'meta_package': 'linux-image-generic',
          'version': '3.13.0.55.62'


### PR DESCRIPTION
... so that we can fix security issues and move to better, more recent,
kernels without reinstall.

NB: There is a problem with most of our VM templates that means we're on
grub-legacy (v1), which in turn was preventing the newer kernels from being
selectable on boot. Hence, make upgrading grub to grub-pc (v2) a prereq.