### PR TITLE
Fix default value for grub_install_device in map.jinja

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 3.0.2 (unreleased)
+
+* Fix default value for grub_install_device in map.jinja
+
 ## Version 3.0.1
 
 * Bug fix syntax error in previous release's map.jinja file

--- a/bootstrap/map.jinja
+++ b/bootstrap/map.jinja
@@ -2,7 +2,7 @@
 
     'Ubuntu-12.04': {
        'upgrade_grub': True,
-       'grub_install_device': salt['grains.get']('SSDs:0') or '/dev/sda',
+       'grub_install_device': '/dev/' + (salt['grains.get']('SSDs:0') or 'sda'),
        'kernel': {
          'meta_package': 'linux-image-generic-lts-trusty',
          'version': '3.13.0.55.48'
@@ -11,7 +11,7 @@
 
     'Ubuntu-14.04': {
        'upgrade_grub': True,
-       'grub_install_device': salt['grains.get']('SSDs:0') or '/dev/sda',
+       'grub_install_device': '/dev/' + (salt['grains.get']('SSDs:0') or 'sda'),
        'kernel': {
          'meta_package': 'linux-image-generic',
          'version': '3.13.0.55.62'


### PR DESCRIPTION
salt['grains.get']('SSDs:0') returns the device name without /dev