### PR TITLE
Default the kernel version to the latest available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UNRELEASED
+
+* Default the kernel version to the latest available
+
 ## Version 3.0.4
 
 * Update the default kernel versions for ubuntu 3.13.0.58.65

--- a/bootstrap/map.jinja
+++ b/bootstrap/map.jinja
@@ -5,7 +5,7 @@
        'grub_install_device': '/dev/' + (salt['grains.get']('SSDs:0') or 'sda'),
        'kernel': {
          'meta_package': 'linux-image-generic-lts-trusty',
-         'version': '3.13.0.58.50'
+         'version': (salt['pkg.latest_version]('linux-image-generic-lts-trusty')) 
        }
     },
 
@@ -14,7 +14,7 @@
        'grub_install_device': '/dev/' + (salt['grains.get']('SSDs:0') or 'sda'),
        'kernel': {
          'meta_package': 'linux-image-generic',
-         'version': '3.13.0.58.65'
+         'version': (salt['pkg.latest_version]('linux-image-generic')) 
        }
     },
 

--- a/bootstrap/map.jinja
+++ b/bootstrap/map.jinja
@@ -5,7 +5,7 @@
        'grub_install_device': '/dev/' + (salt['grains.get']('SSDs:0') or 'sda'),
        'kernel': {
          'meta_package': 'linux-image-generic-lts-trusty',
-         'version': (salt['pkg.latest_version]('linux-image-generic-lts-trusty')) 
+         'version': (salt['pkg.latest_version']('linux-image-generic-lts-trusty')) 
        }
     },
 
@@ -14,7 +14,7 @@
        'grub_install_device': '/dev/' + (salt['grains.get']('SSDs:0') or 'sda'),
        'kernel': {
          'meta_package': 'linux-image-generic',
-         'version': (salt['pkg.latest_version]('linux-image-generic')) 
+         'version': (salt['pkg.latest_version']('linux-image-generic')) 
        }
     },
 


### PR DESCRIPTION
Specifying the kernel version in map.jinja manually means that the
value must be updated and a new release made everytime ubuntu upgrades
a kernel version and deprecates the previous one. This change makes
salt lookup the latest available kernel version and default to using
that.

(Closes ministryofjustice/bootstrap-formula#10)